### PR TITLE
Add configurable plan size and sprint cadence (#25)

### DIFF
--- a/.agent_result.md
+++ b/.agent_result.md
@@ -1,14 +1,15 @@
 STATUS: complete
 
 SUMMARY:
-Added automatic focus area extraction to the strategic planner. When STRATEGY.md has 3+ sprint entries, a Haiku LLM call analyzes sprint history to identify 3-5 recurring work themes and updates the 'Current Focus Areas' section. User-edited content is preserved via an HTML comment marker (`<!-- auto-focus-areas -->`); if the marker is absent and the section contains non-placeholder content, the update is skipped.
+Made plan size and sprint cadence configurable per-repository. Added `plan_size` and `sprint_cadence_days` as top-level config fields with per-repo overrides via `github_projects` repos entries. The retrospective window automatically adjusts to match the configured sprint cadence. Defaults to current behavior (5 tasks, 7 days) when not configured.
 
 DONE:
-- Added `_call_haiku()`, `_extract_sprint_entries()`, `_is_focus_areas_manually_edited()`, `_analyze_focus_areas()`, and `_update_focus_areas_section()` functions to `orchestrator/strategic_planner.py`
-- Integrated focus area update into `_update_strategy()` — runs after sprint entry is added, only when 3+ entries exist
-- Added `FOCUS_AREA_MODEL = "haiku"`, `MIN_SPRINTS_FOR_FOCUS = 3`, and `FOCUS_AREA_MARKER` constants
-- Updated `_STRATEGY_TEMPLATE` to include auto-focus marker in new STRATEGY.md files
-- Created 16 tests covering entry extraction, manual edit detection, section replacement, and LLM response parsing
+- Added `DEFAULT_PLAN_SIZE` and `DEFAULT_SPRINT_CADENCE_DAYS` constants replacing hardcoded `PLAN_SIZE`
+- Added `_repo_planner_config()` helper that resolves per-repo overrides from `github_projects` config
+- Updated `plan_repo()` to use configured values for plan size and retrospective window
+- Updated `_build_retrospective()` to accept configurable days parameter
+- Updated `example.config.yaml` with new `plan_size` and `sprint_cadence_days` fields
+- Added 3 tests covering defaults, top-level config, and per-repo overrides
 
 BLOCKERS:
 - None
@@ -19,22 +20,21 @@ None
 FILES_CHANGED:
 - orchestrator/strategic_planner.py
 - tests/test_strategic_planner.py
+- example.config.yaml
 
 TESTS_RUN:
-- python -m pytest tests/test_strategic_planner.py -v — 16 passed
-- python -m pytest tests/ -v — 66 passed (all tests including existing)
+- pytest tests/test_strategic_planner.py -v — 19 passed
 
 DECISIONS:
-- Used an HTML comment marker (`<!-- auto-focus-areas -->`) to distinguish auto-generated focus areas from manually edited ones — preserves user content without requiring a separate config flag
-- Haiku model used for focus area analysis (cheap, fast) while planning stays on the existing model
-- Capped sprint entries sent to Haiku at 10 most recent to keep prompts bounded
-- Focus area analysis is non-blocking — failures are logged but don't prevent the strategy update
+- Used top-level `plan_size` and `sprint_cadence_days` as global defaults, with per-repo overrides in `github_projects.*.repos[].plan_size` and `github_projects.*.repos[].sprint_cadence_days` — matches existing per-repo config patterns
+- Renamed `PLAN_SIZE` to `DEFAULT_PLAN_SIZE` to clarify it's a fallback, not a fixed value
+- Made `_build_retrospective()` accept a `days` parameter rather than reading config itself — keeps the function pure and testable
 
 RISKS:
-- If STRATEGY.md was created before this change (no marker in template), the first focus area update will treat the placeholder as non-manual and overwrite it, which is the desired behavior
+- None — fully backward compatible, defaults match existing hardcoded values
 
 ATTEMPTED_APPROACHES:
-- Implemented focus area extraction as pure functions integrated into the existing `_update_strategy()` flow rather than a separate module — keeps the diff minimal and leverages the existing commit/push logic
+- Direct approach: added config resolution helper and threaded values through existing call chain — worked on first attempt
 
 MANUAL_STEPS:
 - None

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -16,6 +16,9 @@ default_max_attempts: 4
 max_parallel_workers: 1
 test_timeout_minutes: 5             # Timeout for test commands (default: 5)
 
+plan_size: 5                         # Number of tasks per sprint plan (default: 5)
+sprint_cadence_days: 7               # Sprint length in days (default: 7); retrospective window matches this
+
 priority_weights:                   # Score added per priority label (default: prio:normal=10)
   prio:high: 30
   prio:normal: 10

--- a/orchestrator/strategic_planner.py
+++ b/orchestrator/strategic_planner.py
@@ -30,7 +30,8 @@ from orchestrator.agent_scorer import load_recent_metrics
 from orchestrator.gh_project import query_project, set_item_status, edit_issue_labels, ensure_labels
 from orchestrator.trust import is_trusted
 
-PLAN_SIZE = 5
+DEFAULT_PLAN_SIZE = 5
+DEFAULT_SPRINT_CADENCE_DAYS = 7
 ANALYSIS_MODEL = "opus"
 FOCUS_AREA_MODEL = "haiku"
 METRICS_WINDOW_DAYS = 30
@@ -453,17 +454,17 @@ def _update_strategy(
         print(f"  Warning: failed to push STRATEGY.md for {repo_name}: {e}")
 
 
-def _build_retrospective(repo: str) -> str:
+def _build_retrospective(repo: str, days: int = DEFAULT_SPRINT_CADENCE_DAYS) -> str:
     """Build a retrospective summary of the last sprint's outcomes."""
-    closed = _recently_closed_issues(repo, days=7)
-    merged = _recent_merged_prs(repo, days=7)
+    closed = _recently_closed_issues(repo, days=days)
+    merged = _recent_merged_prs(repo, days=days)
     parts = []
     if closed and not closed.startswith("(no"):
         parts.append(f"Issues completed:\n{closed}")
     if merged and not merged.startswith("(no"):
         parts.append(f"PRs merged:\n{merged}")
     if not parts:
-        return "(no activity in the last week)"
+        return f"(no activity in the last {days} days)"
     return "\n\n".join(parts)
 
 
@@ -789,13 +790,32 @@ def _resolve_repos(cfg: dict) -> list[tuple[str, Path]]:
     return unique
 
 
+def _repo_planner_config(cfg: dict, github_slug: str) -> tuple[int, int]:
+    """Return (plan_size, sprint_cadence_days) for a repo, checking per-repo overrides."""
+    plan_size = cfg.get("plan_size", DEFAULT_PLAN_SIZE)
+    cadence = cfg.get("sprint_cadence_days", DEFAULT_SPRINT_CADENCE_DAYS)
+
+    # Check github_projects for per-repo overrides
+    for pv in cfg.get("github_projects", {}).values():
+        if not isinstance(pv, dict):
+            continue
+        for rc in pv.get("repos", []):
+            if rc.get("github_repo") == github_slug:
+                plan_size = rc.get("plan_size", plan_size)
+                cadence = rc.get("sprint_cadence_days", cadence)
+                return int(plan_size), int(cadence)
+
+    return int(plan_size), int(cadence)
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def plan_repo(cfg: dict, github_slug: str, repo_path: Path) -> tuple[list[dict] | None, str]:
     """Generate a sprint plan for one repo. Returns (plan, retrospective) or (None, "")."""
-    print(f"\n--- Planning {github_slug} ---")
+    plan_size, sprint_cadence_days = _repo_planner_config(cfg, github_slug)
+    print(f"\n--- Planning {github_slug} (plan_size={plan_size}, cadence={sprint_cadence_days}d) ---")
 
     # 1. Read product context
     readme_goal = _read_readme_goal(repo_path)
@@ -813,8 +833,8 @@ def plan_repo(cfg: dict, github_slug: str, repo_path: Path) -> tuple[list[dict] 
     codebase_context = _read_codebase_md(repo_path)
     print(f"  CODEBASE.md: {len(codebase_context)} chars")
 
-    # 4. Sprint retrospective — what shipped last week
-    retrospective = _build_retrospective(github_slug)
+    # 4. Sprint retrospective — what shipped last sprint
+    retrospective = _build_retrospective(github_slug, days=sprint_cadence_days)
     print(f"  Retrospective: {len(retrospective)} chars")
 
     # 5. Last 30 git commits
@@ -838,7 +858,7 @@ def plan_repo(cfg: dict, github_slug: str, repo_path: Path) -> tuple[list[dict] 
 
     # 10. Build prompt with all context
     prompt = PLAN_PROMPT.format(
-        plan_size=PLAN_SIZE,
+        plan_size=plan_size,
         strategy_context=strategy_context,
         readme_goal=readme_goal,
         codebase_context=codebase_context,
@@ -870,7 +890,7 @@ def plan_repo(cfg: dict, github_slug: str, repo_path: Path) -> tuple[list[dict] 
         return None, ""
 
     print(f"  Generated {len(plan)} tasks")
-    return plan[:PLAN_SIZE], retrospective
+    return plan[:plan_size], retrospective
 
 
 def _set_issues_ready(cfg: dict, github_slug: str, issue_urls: list[str]):

--- a/tests/test_strategic_planner.py
+++ b/tests/test_strategic_planner.py
@@ -1,4 +1,4 @@
-"""Tests for strategic_planner focus area analysis."""
+"""Tests for strategic_planner focus area analysis and configuration."""
 from __future__ import annotations
 
 import sys
@@ -9,9 +9,12 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from orchestrator.strategic_planner import (
+    DEFAULT_PLAN_SIZE,
+    DEFAULT_SPRINT_CADENCE_DAYS,
     FOCUS_AREA_MARKER,
     _extract_sprint_entries,
     _is_focus_areas_manually_edited,
+    _repo_planner_config,
     _update_focus_areas_section,
     _analyze_focus_areas,
 )
@@ -233,3 +236,56 @@ def test_analyze_focus_areas_handles_bad_json():
     with patch("orchestrator.strategic_planner._call_haiku", return_value="not json"):
         result = _analyze_focus_areas(["s1", "s2", "s3"])
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _repo_planner_config
+# ---------------------------------------------------------------------------
+
+def test_repo_planner_config_defaults():
+    """Returns defaults when no config is set."""
+    plan_size, cadence = _repo_planner_config({}, "owner/repo")
+    assert plan_size == DEFAULT_PLAN_SIZE
+    assert cadence == DEFAULT_SPRINT_CADENCE_DAYS
+
+
+def test_repo_planner_config_top_level():
+    """Top-level plan_size and sprint_cadence_days are used."""
+    cfg = {"plan_size": 8, "sprint_cadence_days": 14}
+    plan_size, cadence = _repo_planner_config(cfg, "owner/repo")
+    assert plan_size == 8
+    assert cadence == 14
+
+
+def test_repo_planner_config_per_repo_override():
+    """Per-repo config in github_projects overrides top-level."""
+    cfg = {
+        "plan_size": 5,
+        "sprint_cadence_days": 7,
+        "github_projects": {
+            "proj1": {
+                "repos": [
+                    {
+                        "github_repo": "owner/repo-a",
+                        "plan_size": 10,
+                        "sprint_cadence_days": 14,
+                    },
+                    {"github_repo": "owner/repo-b"},
+                ]
+            }
+        },
+    }
+    # repo-a gets overrides
+    plan_size, cadence = _repo_planner_config(cfg, "owner/repo-a")
+    assert plan_size == 10
+    assert cadence == 14
+
+    # repo-b falls back to top-level
+    plan_size, cadence = _repo_planner_config(cfg, "owner/repo-b")
+    assert plan_size == 5
+    assert cadence == 7
+
+    # unknown repo falls back to top-level
+    plan_size, cadence = _repo_planner_config(cfg, "owner/other")
+    assert plan_size == 5
+    assert cadence == 7


### PR DESCRIPTION
## Summary
- Replaces hardcoded `PLAN_SIZE=5` and 7-day retrospective window with configurable `plan_size` and `sprint_cadence_days` fields in config.yaml
- Supports per-repo overrides via `github_projects` repos entries (e.g., bi-weekly sprints or different task counts)
- Fully backward compatible — defaults to current behavior (5 tasks, 7 days) when not configured

## Test plan
- [x] Unit tests for `_repo_planner_config()` covering defaults, top-level config, and per-repo overrides (3 new tests)
- [x] All 19 existing + new tests pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)