### PR TITLE
test: validate PR-165 CI closure and PR-98 cascading fix (#186)

### DIFF
--- a/.agent_result.md
+++ b/.agent_result.md
@@ -1,0 +1,46 @@
+STATUS: complete
+
+BLOCKER_CODE:
+none
+
+SUMMARY:
+PR-165 was already merged with all CI checks passing (SUCCESS). The PR-98 cascading-CI fix (persistent failed_checks in frontmatter) worked correctly: only 2 follow-up tasks were spawned (#166, #170) before the chain terminated, compared to 8+ cascading tasks in the pre-fix PR-98 incident. Added a regression test for failed_checks propagation through follow-up task creation to complete test coverage of the anti-cascade mechanism.
+
+DONE:
+- Confirmed PR-165 is merged with passing CI (all 3 check runs SUCCESS)
+- Confirmed zero further follow-up debug tasks spawned after #170 closed
+- Validated PR-98 fix: failed_checks persisted in frontmatter at dispatch, read by verification gate, propagated through follow-ups
+- Added test_create_followup_task_propagates_failed_checks regression test
+- Verified existing test_verify_pr_ci_debug_completion_uses_meta_failed_checks_over_body passes
+- Full test suite passes (395 tests)
+
+BLOCKERS:
+- None
+
+NEXT_STEP:
+None
+
+FILES_CHANGED:
+- tests/test_queue.py
+
+TESTS_RUN:
+- python -m pytest tests/test_queue.py::test_create_followup_task_propagates_failed_checks -xvs → PASSED
+- python -m pytest tests/test_queue.py::test_verify_pr_ci_debug_completion_uses_meta_failed_checks_over_body -xvs → PASSED
+- python -m pytest tests/ -x → 395 passed in 19.58s
+
+DECISIONS:
+- No code fix needed — PR-165 was already merged with green CI; this task validates closure and prevention
+- Added follow-up propagation test as the missing coverage gap — the verification gate test existed but propagation through create_followup_task was untested
+- No PR-98 gap found — the fix correctly prevents cascading follow-ups (2 follow-ups vs 8+ pre-fix)
+
+RISKS:
+- None identified
+
+ATTEMPTED_APPROACHES:
+- Investigated PR-165 state via gh CLI — found it already merged with SUCCESS status
+- Traced the follow-up chain: #156 → PR-165 → #166 → #170 (all closed, done)
+- Audited failed_checks code paths in queue.py and github_dispatcher.py
+- Added missing propagation test
+
+MANUAL_STEPS:
+- None


### PR DESCRIPTION
## Summary
- Confirmed PR-165 already merged with passing CI — no code fix needed
- Validated PR-98 cascading-CI fix worked: only 2 follow-ups (#166, #170) vs 8+ pre-fix
- Added `test_create_followup_task_propagates_failed_checks` regression test covering the missing gap in follow-up propagation

## Test plan
- [x] New test passes: `pytest tests/test_queue.py::test_create_followup_task_propagates_failed_checks`
- [x] Existing cascading fix test passes: `pytest tests/test_queue.py::test_verify_pr_ci_debug_completion_uses_meta_failed_checks_over_body`
- [x] Full suite: 395 passed

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)