### PR TITLE
Unblock stuck agent PRs: scope rule and post-rebase runner

### DIFF
--- a/orchestrator/pr_monitor.py
+++ b/orchestrator/pr_monitor.py
@@ -161,6 +161,34 @@ def _try_union_resolve(worktree_path: Path, conflict_files: list[str]) -> bool:
     return True
 
 
+def _detect_post_rebase_test_command(worktree_path: Path) -> list[str] | None:
+    """Pick the right test runner for post-rebase validation based on the repo layout.
+
+    Hardcoding ``python3 -m pytest tests/`` previously caused every conflicting
+    PR on a JS or static-content repo (eigendark-website, liminalconsultants)
+    to be force-reset, never recovered, because pytest exits non-zero when
+    there is no ``tests/`` directory. Returns ``None`` when no test runner is
+    available so the caller can skip validation rather than spuriously revert.
+    """
+    has_pytest = (worktree_path / "tests").is_dir() and (
+        (worktree_path / "pyproject.toml").exists() or (worktree_path / "setup.py").exists()
+    )
+    if has_pytest:
+        return ["python3", "-m", "pytest", "tests/", "-x", "-q", "--tb=no"]
+
+    package_json = worktree_path / "package.json"
+    if package_json.exists():
+        try:
+            data = json.loads(package_json.read_text(encoding="utf-8"))
+            scripts = data.get("scripts") or {}
+            if isinstance(scripts, dict) and "test" in scripts:
+                return ["npm", "test", "--silent", "--", "--passWithNoTests"]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    return None
+
+
 def _rebase_pr_onto_main(repo: str, pr: dict) -> bool:
     """Rebase a conflicting agent PR branch onto main and force-push. Returns True on success."""
     branch = pr.get("headRefName", "")
@@ -232,19 +260,26 @@ def _rebase_pr_onto_main(repo: str, pr: dict) -> bool:
                 return False
 
             if step > 0:
-                # Validate with tests after conflict resolution
-                test_result = subprocess.run(
-                    ["python3", "-m", "pytest", "tests/", "-x", "-q", "--tb=no"],
-                    capture_output=True, text=True, cwd=str(worktree_path), timeout=120,
-                )
-                if test_result.returncode != 0:
-                    print(f"  Tests failed after auto-resolved rebase, reverting")
-                    # Can't abort after rebase completed — reset branch to pre-rebase state
-                    subprocess.run(
-                        ["git", "-C", str(worktree_path), "reset", "--hard", f"origin/{branch}"],
-                        capture_output=True,
+                # Validate with tests after conflict resolution. The runner
+                # depends on the project type — this script previously hardcoded
+                # pytest, which always failed on JS/static-content repos and
+                # caused every conflicting PR to be reset, never recovered.
+                test_cmd = _detect_post_rebase_test_command(worktree_path)
+                if test_cmd:
+                    test_result = subprocess.run(
+                        test_cmd,
+                        capture_output=True, text=True, cwd=str(worktree_path), timeout=180,
                     )
-                    return False
+                    if test_result.returncode != 0:
+                        print(f"  Tests failed after auto-resolved rebase, reverting")
+                        # Can't abort after rebase completed — reset branch to pre-rebase state
+                        subprocess.run(
+                            ["git", "-C", str(worktree_path), "reset", "--hard", f"origin/{branch}"],
+                            capture_output=True,
+                        )
+                        return False
+                else:
+                    print(f"  No test runner detected for {repo} — skipping post-rebase validation")
 
             # Force-push rebased branch
             subprocess.run(

--- a/orchestrator/work_verifier.py
+++ b/orchestrator/work_verifier.py
@@ -381,7 +381,7 @@ def _scope_findings(risk: RiskAssessment, *, issue_body: str) -> list[Verificati
                 severity="medium",
             )
         )
-    if expects_tests and not risk.has_test_changes:
+    if expects_tests and risk.has_source_changes and not risk.has_test_changes:
         findings.append(
             VerificationFinding(
                 category="scope_mismatch",

--- a/tests/test_pr_monitor_test_runner_detection.py
+++ b/tests/test_pr_monitor_test_runner_detection.py
@@ -1,0 +1,48 @@
+"""Regression coverage for the post-rebase test-runner detection.
+
+Incident 2026-04-23: ``_rebase_pr_onto_main`` hardcoded
+``python3 -m pytest tests/`` for post-rebase validation. eigendark-website
+(Next.js) and liminalconsultants (static HTML) have no ``tests/``
+directory, so pytest exited non-zero on every conflicting PR. The
+rebase code interpreted that as "tests failed", reset the branch, and
+left PRs #88 / #95 / #98 stuck for hours with no path to merge.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestrator.pr_monitor import _detect_post_rebase_test_command
+
+
+def test_python_repo_uses_pytest(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    cmd = _detect_post_rebase_test_command(tmp_path)
+    assert cmd == ["python3", "-m", "pytest", "tests/", "-x", "-q", "--tb=no"]
+
+
+def test_js_repo_with_test_script_uses_npm(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "x", "scripts": {"test": "jest"}})
+    )
+    cmd = _detect_post_rebase_test_command(tmp_path)
+    assert cmd is not None
+    assert cmd[0] == "npm"
+    assert "test" in cmd
+
+
+def test_js_repo_without_test_script_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(json.dumps({"name": "x", "scripts": {"build": "next build"}}))
+    assert _detect_post_rebase_test_command(tmp_path) is None
+
+
+def test_static_content_repo_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "sitemap.xml").write_text("<urlset/>")
+    assert _detect_post_rebase_test_command(tmp_path) is None
+
+
+def test_python_without_pyproject_or_setup_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    assert _detect_post_rebase_test_command(tmp_path) is None

--- a/tests/test_work_verifier.py
+++ b/tests/test_work_verifier.py
@@ -142,6 +142,25 @@ def test_scope_findings_only_warns_when_source_changes_lack_tests_unless_issue_r
     assert any(item.category == "scope_mismatch" and item.severity == "high" for item in required)
 
 
+def test_scope_findings_does_not_block_docs_only_pr_when_issue_mentions_verify():
+    """Regression: liminalconsultants PRs #53–56 (docs/HTML/SVG only) were blocked
+    repeatedly because issue bodies casually mentioned "verify" or "test", but
+    the repo has no test infrastructure and the PR has no source changes to test.
+    The high-severity scope_mismatch must require has_source_changes=True."""
+    docs_only = RiskAssessment(
+        level="low",
+        files_changed=3,
+        lines_changed=200,
+        has_source_changes=False,
+        has_test_changes=False,
+    )
+
+    issue_body = "## Goal\nVerify that the breadcrumb infrastructure is discoverable and accessible."
+    findings = _scope_findings(docs_only, issue_body=issue_body)
+    assert not any(item.category == "scope_mismatch" and item.severity == "high" for item in findings)
+    assert not any(item.category == "missing_tests" for item in findings)
+
+
 def test_verify_pull_request_blocks_on_stub_without_llm(monkeypatch, tmp_path):
     cfg = {"root_dir": str(tmp_path)}
 


### PR DESCRIPTION
## Summary

Two root causes were leaving agent PRs open for hours across `eigendark-website` and `liminalconsultants` on 2026-04-23. Both are now fixed and pinned with regression tests.

### 1. Over-broad scope_mismatch rule (`work_verifier.py`)
`_scope_findings` escalated `scope_mismatch` to **high** severity whenever the linked issue body contained "verify", "test", "regression", or "coverage" — even when the PR was pure docs/HTML/SVG content with no source files to test. liminalconsultants PRs #53–#56 sat blocked because issues #48–#51 used the word "Verify" in the Goal section.

**Fix:** gate the high-severity finding on `has_source_changes`, so content-only PRs aren't blocked for missing tests that don't apply.

### 2. Hardcoded pytest as post-rebase validator (`pr_monitor.py`)
`_rebase_pr_onto_main` ran `python3 -m pytest tests/` after every auto-resolved rebase. eigendark-website (Next.js + vitest) and liminalconsultants (static HTML) have no `tests/` directory, so pytest exited non-zero on every conflicting PR. The rebase code interpreted that as test failure, reset the branch, and left PRs #88 / #95 / #98 stuck for hours despite their only conflict being the disposable `.agent_result.md` metadata file.

**Fix:** `_detect_post_rebase_test_command` picks pytest for Python projects, `npm test` for JS projects with a test script, and skips validation when neither applies (rather than spuriously reverting).

## Test plan
- [x] `pytest tests/test_work_verifier.py tests/test_pr_monitor_test_runner_detection.py tests/test_pr_monitor_stuck.py` — 21 passed
- [x] Manual `pr_monitor` run unblocked liminalconsultants #53–#56 (merged)
- [x] Manual rebase of eigendark-website #88/#95/#98 produced clean branches; vitest passes on each