### PR TITLE
Orphan check must use the repo's actual default branch, not 'main'

### DIFF
--- a/orchestrator/pr_monitor.py
+++ b/orchestrator/pr_monitor.py
@@ -325,8 +325,29 @@ def _open_pr_branches(repo: str) -> set[str]:
         return set()
 
 
-def _branch_has_commits_ahead_of_main(repo: str, branch: str, base: str = "main") -> bool:
+@functools.lru_cache(maxsize=64)
+def _remote_default_branch(repo: str) -> str:
+    """Return the default branch reported by GitHub for `repo`.
+
+    Cached per process. Falls back to "main" only if the API call itself
+    fails (network error / auth). The previous hardcoded "main" silently
+    treated every eigendark agent branch as fully merged because the
+    compare against a non-existent main returns 404 — so the orphan
+    cleanup would have erroneously deleted valid agent branches there.
+    """
+    try:
+        out = gh(["api", f"repos/{repo}", "--jq", ".default_branch"], check=False)
+        candidate = (out or "").strip()
+        if candidate:
+            return candidate
+    except Exception:
+        pass
+    return "main"
+
+
+def _branch_has_commits_ahead_of_main(repo: str, branch: str, base: str | None = None) -> bool:
     """Return True if the branch has at least one commit not on base."""
+    base = base or _remote_default_branch(repo)
     try:
         out = gh(["api", f"repos/{repo}/compare/{base}...{branch}",
                   "--jq", ".ahead_by"], check=False)

--- a/tests/test_orphan_check_default_branch.py
+++ b/tests/test_orphan_check_default_branch.py
@@ -1,0 +1,47 @@
+"""Regression coverage for `_branch_has_commits_ahead_of_main` honoring
+the actual default branch reported by GitHub.
+
+Discovered while diagnosing the 2026-04-23 stuck-PR incident. The
+function previously hardcoded `base="main"`, so on repos that default
+to `master` (e.g. eigendark) the GitHub compare endpoint returns 404 →
+exception caught → False → orphan check treats the agent branch as
+"fully merged" and **deletes a valid branch**. The lookup now consults
+GitHub for the actual default branch.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import orchestrator.pr_monitor as pr_monitor
+
+
+def test_remote_default_branch_returns_master_for_master_repo():
+    pr_monitor._remote_default_branch.cache_clear()
+    with patch("orchestrator.pr_monitor.gh", return_value="master"):
+        assert pr_monitor._remote_default_branch("kai-linux/eigendark") == "master"
+
+
+def test_remote_default_branch_falls_back_to_main_on_failure():
+    pr_monitor._remote_default_branch.cache_clear()
+    with patch("orchestrator.pr_monitor.gh", side_effect=RuntimeError("api down")):
+        assert pr_monitor._remote_default_branch("kai-linux/anything") == "main"
+
+
+def test_branch_has_commits_uses_actual_default_branch():
+    pr_monitor._remote_default_branch.cache_clear()
+    captured: list[list[str]] = []
+
+    def fake_gh(args, check=False):
+        captured.append(args)
+        if "/compare/" in args[1]:
+            return "1"
+        if args[1].startswith("repos/") and "default_branch" in (args[-1] if args else ""):
+            return "master"
+        return "master"
+
+    with patch("orchestrator.pr_monitor.gh", side_effect=fake_gh):
+        assert pr_monitor._branch_has_commits_ahead_of_main("kai-linux/eigendark", "agent/foo") is True
+
+    compare_calls = [a for a in captured if "/compare/" in a[1]]
+    assert compare_calls, "expected a compare API call"
+    assert "master...agent/foo" in compare_calls[0][1]


### PR DESCRIPTION
## Summary
\`_branch_has_commits_ahead_of_main\` hardcoded \`base="main"\` without consulting the repo. On eigendark (default=\`master\`) the GitHub compare endpoint returns 404 → exception caught → False → the orphan check treats every agent branch as "fully merged" and **would delete a valid agent branch**.

The bug only stayed dormant because eigendark hadn't accumulated orphan agent branches yet during this incident window. Found while sweeping for related underlying issues after the PR-stall investigation.

## Fix
New \`_remote_default_branch\` queries \`gh api repos/{repo} --jq .default_branch\` (cached per process), with the original "main" fallback only when the API call itself fails.

## Test plan
- [x] \`pytest tests/test_orphan_check_default_branch.py tests/test_orphan_branch_recreation_loop.py tests/test_pr_monitor_test_runner_detection.py tests/test_pr_monitor_stuck.py\` — 18 passed