### PR TITLE
Init: preserve existing config, prompt for cadence, write supporting docs

### DIFF
--- a/orchestrator/init/__main__.py
+++ b/orchestrator/init/__main__.py
@@ -8,7 +8,7 @@ import yaml
 
 from orchestrator.init import ui
 from orchestrator.init import charter as charter_phase
-from orchestrator.init import config_emit, cron_install, dialogue, github_scaffold, preflight, telegram_pair
+from orchestrator.init import config_emit, cron_install, dialogue, github_scaffold, preflight, telegram_pair, tuning
 from orchestrator.init.state import State, delete_state, resumable_states, slugify_repo_name
 from orchestrator.paths import ROOT
 
@@ -86,8 +86,25 @@ def _print_preflight_results(results: list[preflight.CheckResult]) -> None:
             ui.fail(f"{result.message} — {result.hint}")
 
 
+def _confirm_config_merge_mode(existing_cfg: dict | None) -> str:
+    """Prompt the operator about preserving an existing config.yaml.
+
+    Returns one of: ``merge`` (default), ``abort``. Operators get a clear
+    choice before their existing tuning is touched. Merge mode now preserves
+    scalar settings via setdefault, so the only reason to abort is when the
+    operator wants to hand-edit the file instead.
+    """
+    if not existing_cfg:
+        return "merge"
+    ui.warn("An existing config.yaml was detected.")
+    print("  [1] Add this project to the existing config (merge, preserve current settings)")
+    print("  [2] Abort — I'll edit config.yaml manually")
+    choice = ui.choice("", ["1", "2"], default="1")
+    return "merge" if choice == "1" else "abort"
+
+
 def _final_banner(state: State, telegram: dict[str, str], cron_mode: str) -> None:
-    ui.header("Step 7/7 — Done")
+    ui.header("Step 8/8 — Done")
     github = state.get("github", {})
     print(f"  Repo:     {github.get('repo_url')}")
     print(f"  Project:  {github.get('project_url')}")
@@ -132,12 +149,12 @@ def main() -> int:
         if config_path.exists():
             existing_cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
 
-        ui.header("Step 1/7 — What are you building?")
+        ui.header("Step 1/8 — What are you building?")
         intake = dialogue.run(state.get("intake"))
         if not state.get("intake"):
             state.mark("intake", intake)
 
-        ui.header("Step 2/7 — GitHub repo")
+        ui.header("Step 2/8 — GitHub repo")
         github = github_scaffold.run(state, intake, dry_run=args.dry_run)
 
         expected_slug = slugify_repo_name(github["repo_name"])
@@ -147,18 +164,26 @@ def main() -> int:
             state.path = expected_path
             state.save()
 
-        ui.header("Step 3/7 — Designing the charter")
+        ui.header("Step 3/8 — Designing the charter and supporting docs")
         charter = charter_phase.run(state, intake, github, dry_run=args.dry_run)
 
-        ui.header("Step 4/7 — Telegram control plane")
+        ui.header("Step 4/8 — Telegram control plane")
         telegram = telegram_pair.run(state, github["repo_full_name"], existing_cfg=existing_cfg, dry_run=args.dry_run)
 
-        ui.header("Step 5/7 — Writing config.yaml")
-        config_path = config_emit.run(state, intake, github, charter, telegram, dry_run=args.dry_run)
+        ui.header("Step 5/8 — Tuning cadence and thresholds")
+        tuning_choices = tuning.run(state, existing_cfg=existing_cfg)
+
+        ui.header("Step 6/8 — Writing config.yaml")
+        merge_mode = _confirm_config_merge_mode(existing_cfg)
+        if merge_mode == "abort":
+            ui.warn("Aborted before config.yaml changes. Your saved init state at "
+                    f"{state.path} is preserved; rerun `bin/agentos init` to resume.")
+            return 1
+        config_path = config_emit.run(state, intake, github, charter, telegram, dry_run=args.dry_run, tuning=tuning_choices)
         ui.ok(f"Wrote {config_path}")
         ui.ok(f"Wrote {state.path}")
 
-        ui.header("Step 6/7 — Cron setup")
+        ui.header("Step 7/8 — Cron setup")
         cron_mode = cron_install.run(state, dry_run=args.dry_run)
         state.complete()
 

--- a/orchestrator/init/charter.py
+++ b/orchestrator/init/charter.py
@@ -52,6 +52,9 @@ Output EXACTLY one JSON object, no code fences, no prose before or after. Schema
   "stack_decision": "<one-line stack summary>",
   "stack_rationale": "<2-4 sentence rationale>",
   "north_star_md": "<full markdown body for NORTH_STAR.md — include: one-paragraph mission, stack + rationale, out-of-scope list, definition of first vertical slice>",
+  "vision_md": "<full markdown body for VISION.md — a 2-5 year aspiration for this product: where it is when it's finished, who uses it, what it does for them, what it never will be>",
+  "strategy_md": "<full markdown body for STRATEGY.md — how we get from today's empty repo to the vision: 3-5 ordered phases each with a concrete goal and the kind of work it contains. Not a ticket list — a strategy document>",
+  "planning_principles_md": "<full markdown body for PLANNING_PRINCIPLES.md — non-negotiable rules agents must follow when planning or implementing for this project (e.g. 'prefer boring tech', 'no premature abstraction', 'tests before merge'). 5-10 bullets>",
   "seed_issues": [
     {{
       "title": "<imperative, <= 70 chars>",
@@ -68,6 +71,9 @@ Rules:
 - Each issue must be independently completable — no "depends on issue #2" language.
 - success_criteria bullets must be observable (file exists, command returns 0, endpoint returns 200, etc.)
 - 3-5 issues total. No more.
+- vision_md must describe an end state, not features. Avoid implementation details.
+- strategy_md must sequence phases causally (each phase unlocks the next), not alphabetically.
+- planning_principles_md must give agents actionable constraints, not platitudes.
 """
 
 
@@ -95,6 +101,13 @@ def validate_charter_payload(payload: dict[str, Any]) -> None:
         raise CharterError("Missing stack_decision")
     if not payload.get("north_star_md"):
         raise CharterError("Missing north_star_md")
+    # Newer schema adds VISION/STRATEGY/PLANNING_PRINCIPLES. Treat these as
+    # soft-required: accept older architect outputs that omit them so
+    # mid-flight resumes of an earlier init don't break, but warn via
+    # validation error when a new run yields nothing for them.
+    for soft in ("vision_md", "strategy_md", "planning_principles_md"):
+        if soft in payload and not str(payload.get(soft) or "").strip():
+            raise CharterError(f"{soft} present but empty")
     issues = payload.get("seed_issues")
     if not isinstance(issues, list) or not 3 <= len(issues) <= 5:
         raise CharterError("seed_issues must contain 3-5 issues")
@@ -225,15 +238,37 @@ def _ensure_priority_labels(repo_full_name: str) -> None:
         )
 
 
-def _commit_charter(local_path: Path, markdown_body: str, *, dry_run: bool) -> str:
-    target = local_path / "NORTH_STAR.md"
-    target.write_text(markdown_body.rstrip() + "\n", encoding="utf-8")
+_CHARTER_DOCS = (
+    ("north_star_md", "NORTH_STAR.md"),
+    ("vision_md", "VISION.md"),
+    ("strategy_md", "STRATEGY.md"),
+    ("planning_principles_md", "PLANNING_PRINCIPLES.md"),
+)
+
+
+def _commit_charter(local_path: Path, payload: dict[str, Any], *, dry_run: bool) -> str:
+    """Write each charter markdown doc that the architect produced.
+
+    Older architect outputs only produced NORTH_STAR.md; the schema now also
+    accepts VISION/STRATEGY/PLANNING_PRINCIPLES. Write only the ones actually
+    present in the payload so the commit doesn't leave empty files.
+    """
+    written: list[str] = []
+    for key, filename in _CHARTER_DOCS:
+        body = str(payload.get(key) or "").strip()
+        if not body:
+            continue
+        target = local_path / filename
+        target.write_text(body + "\n", encoding="utf-8")
+        written.append(filename)
     if dry_run:
         return "DRYRUN"
-    subprocess.run(["git", "add", "NORTH_STAR.md"], cwd=local_path, check=True)
+    if not written:
+        raise CharterError("No charter markdown docs produced by architect")
+    subprocess.run(["git", "add", *written], cwd=local_path, check=True)
+    headline = f"Charter: scaffold {', '.join(written)} and seed backlog"
     subprocess.run(
-        ["git", "commit", "-m",
-         with_agent_os_trailer("NORTH_STAR: scaffold charter and seed backlog")],
+        ["git", "commit", "-m", with_agent_os_trailer(headline)],
         cwd=local_path, check=True,
     )
     subprocess.run(["git", "push"], cwd=local_path, check=True)
@@ -316,7 +351,7 @@ def run(state: State, intake: dict[str, str], github: dict[str, Any], *, dry_run
 
     local_path = Path(github["local_clone_path"]).expanduser()
     if not state.get("charter.committed_sha"):
-        sha = _commit_charter(local_path, charter_data["north_star_md"], dry_run=dry_run)
+        sha = _commit_charter(local_path, charter_data, dry_run=dry_run)
         state.merge("charter", {"committed_sha": sha})
 
     if not state.get("issues_created"):

--- a/orchestrator/init/config_emit.py
+++ b/orchestrator/init/config_emit.py
@@ -184,12 +184,18 @@ def merge_config(existing: dict[str, Any], intake: dict[str, str], github: dict[
     merged.setdefault("github_project_blocked_value", status_values["Blocked"])
     merged.setdefault("github_project_done_value", status_values["Done"])
 
+    # github_repos / github_projects: only register the new repo when it
+    # isn't already in the existing config. Re-running init for an existing
+    # repo used to silently overwrite its entry; preserve the operator's
+    # previous edits instead.
     github_repos = dict(merged.get("github_repos") or {})
-    github_repos[repo_name] = github["repo_full_name"]
+    github_repos.setdefault(repo_name, github["repo_full_name"])
     merged["github_repos"] = github_repos
 
     github_projects = dict(merged.get("github_projects") or {})
-    github_projects.update(_project_entry(github))
+    new_project_entry = _project_entry(github)
+    for key, value in new_project_entry.items():
+        github_projects.setdefault(key, value)
     merged["github_projects"] = github_projects
 
     trusted_authors = list(merged.get("trusted_authors") or [])
@@ -197,13 +203,44 @@ def merge_config(existing: dict[str, Any], intake: dict[str, str], github: dict[
         trusted_authors.append(github["owner"])
     merged["trusted_authors"] = trusted_authors
 
-    merged["telegram_bot_token"] = telegram["token"]
-    merged["telegram_chat_id"] = str(telegram["chat_id"])
+    # Preserve existing Telegram credentials — the operator has already paired
+    # a bot and the new repo does not supersede that pairing. Only write when
+    # absent.
+    merged.setdefault("telegram_bot_token", telegram["token"])
+    merged.setdefault("telegram_chat_id", str(telegram["chat_id"]))
     merged.setdefault("dependency_watcher", {"enabled": True, "cadence_days": 7, "max_actions_per_week": 3})
     return merged
 
 
-def run(state, intake: dict[str, str], github: dict[str, Any], charter: dict[str, Any], telegram: dict[str, str], *, dry_run: bool = False) -> Path:
+def apply_tuning(payload: dict[str, Any], tuning: dict[str, Any] | None) -> dict[str, Any]:
+    """Overlay interactive tuning choices onto a config payload.
+
+    Only applies keys the operator explicitly chose (present in tuning).
+    Nested keys like ``dependency_watcher.cadence_days`` merge into the
+    existing nested dict rather than replacing it.
+    """
+    if not tuning:
+        return payload
+    for key, value in tuning.items():
+        if key == "dependency_watcher_cadence_days":
+            dw = dict(payload.get("dependency_watcher") or {})
+            dw["cadence_days"] = value
+            payload["dependency_watcher"] = dw
+            continue
+        payload[key] = value
+    return payload
+
+
+def run(
+    state,
+    intake: dict[str, str],
+    github: dict[str, Any],
+    charter: dict[str, Any],
+    telegram: dict[str, str],
+    *,
+    dry_run: bool = False,
+    tuning: dict[str, Any] | None = None,
+) -> Path:
     config_path = ROOT / "config.yaml"
     _ensure_hooks_path()
     existing_cfg = None
@@ -212,9 +249,16 @@ def run(state, intake: dict[str, str], github: dict[str, Any], charter: dict[str
         existing_cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         backup = config_path.with_name(f"config.yaml.bak.{ts}")
-        shutil.move(str(config_path), str(backup))
+        # Copy (not move) the backup so the existing config stays readable
+        # until the merged file replaces it atomically. Prevents a race where
+        # a concurrent reader sees a missing config mid-swap.
+        shutil.copy2(str(config_path), str(backup))
 
-    payload = merge_config(existing_cfg, intake, github, charter, telegram) if existing_cfg is not None else build_config(intake, github, charter, telegram)
+    if existing_cfg is not None:
+        payload = merge_config(existing_cfg, intake, github, charter, telegram)
+    else:
+        payload = build_config(intake, github, charter, telegram)
+    payload = apply_tuning(payload, tuning)
     yaml_text = yaml.safe_dump(payload, sort_keys=False)
     if not dry_run:
         config_path.write_text(yaml_text, encoding="utf-8")

--- a/orchestrator/init/tuning.py
+++ b/orchestrator/init/tuning.py
@@ -1,0 +1,135 @@
+"""Interactive tuning step for `agentos init`.
+
+Walks the operator through cadence and concurrency settings so a newly
+onboarded project isn't silently stuck with the hardcoded defaults.
+
+When an existing ``config.yaml`` already has a value set, that existing
+value is shown as the default so "just hit enter" preserves what the
+operator already tuned — don't make them re-type the same number every
+time they add a new project.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from orchestrator.init import ui
+from orchestrator.init.state import State
+
+
+@dataclass(frozen=True)
+class TuningField:
+    key: str
+    prompt: str
+    default: Any
+    cast: type
+    hint: str
+
+    def explain(self) -> str:
+        return f"{self.prompt}\n  ({self.hint})"
+
+
+# Each field corresponds to a config.yaml key the operator should be aware of.
+# `dependency_watcher_cadence_days` is flattened here and re-nested by
+# ``config_emit.apply_tuning``.
+_FIELDS: tuple[TuningField, ...] = (
+    TuningField(
+        key="sprint_cadence_days",
+        prompt="Strategic planner cadence (days)",
+        default=7,
+        cast=int,
+        hint="How often the planner re-prioritizes the backlog. 7 = weekly sprints.",
+    ),
+    TuningField(
+        key="groomer_cadence_days",
+        prompt="Backlog groomer cadence (days)",
+        default=3.5,
+        cast=float,
+        hint="How often the groomer generates new issues for this repo. 3.5 = twice a week.",
+    ),
+    TuningField(
+        key="max_parallel_workers",
+        prompt="Max parallel agent workers",
+        default=1,
+        cast=int,
+        hint="Tasks running at the same time. Start at 1; raise only after you've observed stability.",
+    ),
+    TuningField(
+        key="max_runtime_minutes",
+        prompt="Per-task runtime cap (minutes)",
+        default=40,
+        cast=int,
+        hint="Hard timeout for a single agent run. Tasks exceeding this are marked failed.",
+    ),
+    TuningField(
+        key="plan_size",
+        prompt="Issues the groomer generates per run",
+        default=5,
+        cast=int,
+        hint="Batch size. 3-5 is a good range for solo operators.",
+    ),
+    TuningField(
+        key="default_max_attempts",
+        prompt="Retries before giving up on a task",
+        default=4,
+        cast=int,
+        hint="Each retry re-dispatches the task with a fresh worktree.",
+    ),
+    TuningField(
+        key="dependency_watcher_cadence_days",
+        prompt="Dependency watcher cadence (days)",
+        default=7,
+        cast=int,
+        hint="How often the watcher checks for dependency updates. 0 disables.",
+    ),
+)
+
+
+def _resolve_default(field: TuningField, existing_cfg: dict | None) -> Any:
+    if not existing_cfg:
+        return field.default
+    if field.key == "dependency_watcher_cadence_days":
+        dw = existing_cfg.get("dependency_watcher") or {}
+        return dw.get("cadence_days", field.default)
+    return existing_cfg.get(field.key, field.default)
+
+
+def _cast_or_default(raw: str, field: TuningField, default: Any) -> Any:
+    value = (raw or "").strip()
+    if not value:
+        return default
+    try:
+        return field.cast(value)
+    except ValueError:
+        ui.warn(f"Could not parse {value!r} as {field.cast.__name__}; keeping {default}.")
+        return default
+
+
+def run(state: State, *, existing_cfg: dict | None = None) -> dict[str, Any]:
+    """Prompt the operator for cadence & threshold values.
+
+    Returns a dict of tuning overrides (empty when operator accepts all
+    defaults). The caller passes this to ``config_emit.run`` which overlays
+    it onto the generated config payload.
+    """
+    if state.get("tuning"):
+        return state.get("tuning")
+
+    print("These control how fast the orchestrator runs your project. Press ")
+    print("enter on each to accept the shown default — it's the current value ")
+    print("from config.yaml when one exists, otherwise the Agent OS default.")
+    print()
+
+    tuning: dict[str, Any] = {}
+    for field in _FIELDS:
+        default = _resolve_default(field, existing_cfg)
+        raw = ui.prompt(field.explain(), default=str(default))
+        chosen = _cast_or_default(raw, field, default)
+        # Only record the choice when it differs from the existing-config
+        # default, so we don't churn the file with identical values.
+        existing_value = _resolve_default(field, existing_cfg)
+        if chosen != existing_value:
+            tuning[field.key] = chosen
+
+    state.mark("tuning", tuning)
+    return tuning

--- a/tests/test_init_charter.py
+++ b/tests/test_init_charter.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from orchestrator.init.charter import (
     CharterError,
+    _commit_charter,
     build_revision_prompt,
     call_architect,
     parse_charter_response,
@@ -106,3 +107,58 @@ def test_build_revision_prompt_includes_plain_language_feedback():
     assert "Operator feedback" in prompt
     assert "I don't want Netlify" in prompt
     assert '"stack_decision": "Quart + SQLite"' in prompt
+
+
+def test_validate_charter_payload_rejects_empty_optional_docs():
+    payload = _payload()
+    payload["vision_md"] = ""
+    with pytest.raises(CharterError, match="vision_md present but empty"):
+        validate_charter_payload(payload)
+
+
+def test_validate_charter_payload_accepts_legacy_without_optional_docs():
+    # Older architect output that only has north_star_md must still validate —
+    # a resumed init from a previous version should not fail.
+    payload = _payload()
+    assert "vision_md" not in payload
+    validate_charter_payload(payload)  # no raise
+
+
+def test_commit_charter_writes_all_present_markdown_docs(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
+        calls.append(list(cmd))
+        if "rev-parse" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("orchestrator.init.charter.subprocess.run", fake_run)
+    payload = _payload()
+    payload["vision_md"] = "# Vision\nEnd state."
+    payload["strategy_md"] = "# Strategy\n1. Phase one\n2. Phase two"
+    payload["planning_principles_md"] = "- Prefer boring tech\n- Test before merge"
+
+    sha = _commit_charter(tmp_path, payload, dry_run=False)
+
+    assert sha == "abc123"
+    assert (tmp_path / "NORTH_STAR.md").read_text().startswith("# Demo")
+    assert (tmp_path / "VISION.md").read_text().startswith("# Vision")
+    assert (tmp_path / "STRATEGY.md").read_text().startswith("# Strategy")
+    assert (tmp_path / "PLANNING_PRINCIPLES.md").read_text().startswith("- Prefer")
+    # `git add` should reference all four files.
+    add_cmd = next(c for c in calls if c[:2] == ["git", "add"])
+    for name in ("NORTH_STAR.md", "VISION.md", "STRATEGY.md", "PLANNING_PRINCIPLES.md"):
+        assert name in add_cmd
+
+
+def test_commit_charter_skips_missing_optional_docs(tmp_path, monkeypatch):
+    """Legacy payloads with only north_star_md must commit cleanly."""
+    monkeypatch.setattr("orchestrator.init.charter.subprocess.run",
+                       lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="abc\n", stderr=""))
+    payload = _payload()  # no vision/strategy/principles
+    _commit_charter(tmp_path, payload, dry_run=False)
+    assert (tmp_path / "NORTH_STAR.md").exists()
+    assert not (tmp_path / "VISION.md").exists()
+    assert not (tmp_path / "STRATEGY.md").exists()
+    assert not (tmp_path / "PLANNING_PRINCIPLES.md").exists()

--- a/tests/test_init_config_emit.py
+++ b/tests/test_init_config_emit.py
@@ -81,5 +81,86 @@ def test_merge_config_preserves_existing_repos_and_adds_new_one(tmp_path):
     assert str(tmp_path / "demo") in merged["allowed_repos"]
     assert "agent-os" in merged["github_projects"]
     assert "demo" in merged["github_projects"]
+    # Existing Telegram credentials must survive — the operator has already
+    # paired a bot and adding a new repo shouldn't clobber that pairing.
+    assert merged["telegram_bot_token"] == "existing-token"
+    assert merged["telegram_chat_id"] == "123"
+
+
+def test_merge_config_writes_telegram_when_not_previously_set(tmp_path):
+    existing = {"allowed_repos": ["/old/repo"]}
+    merged = merge_config(
+        existing,
+        {"kind": "web"},
+        {
+            "owner": "kai-linux",
+            "repo_name": "demo",
+            "repo_full_name": "kai-linux/demo",
+            "project_number": 14,
+            "local_clone_path": str(tmp_path / "demo"),
+            "status_value_names": {"Ready": "Todo", "In Progress": "In Progress", "Blocked": "Todo", "Done": "Done"},
+        },
+        {"stack_decision": "Quart + SQLite"},
+        {"token": "new-token", "chat_id": "999"},
+    )
     assert merged["telegram_bot_token"] == "new-token"
     assert merged["telegram_chat_id"] == "999"
+
+
+def test_merge_config_preserves_existing_github_project_entry(tmp_path):
+    existing = {
+        "github_projects": {
+            "demo": {
+                "project_number": 99,  # operator previously customized
+                "repos": [{"key": "demo", "github_repo": "kai-linux/demo", "local_repo": "/custom/path"}],
+            }
+        },
+        "github_repos": {"demo": "kai-linux/demo"},
+    }
+    merged = merge_config(
+        existing,
+        {"kind": "web"},
+        {
+            "owner": "kai-linux",
+            "repo_name": "demo",
+            "repo_full_name": "kai-linux/demo",
+            "project_number": 14,
+            "local_clone_path": str(tmp_path / "demo"),
+            "status_value_names": {"Ready": "Todo", "In Progress": "In Progress", "Blocked": "Todo", "Done": "Done"},
+        },
+        {"stack_decision": "Quart + SQLite"},
+        {"token": "t", "chat_id": "1"},
+    )
+    # Re-running init for an existing repo must not clobber the operator's
+    # customized project entry.
+    assert merged["github_projects"]["demo"]["project_number"] == 99
+    assert merged["github_projects"]["demo"]["repos"][0]["local_repo"] == "/custom/path"
+    assert merged["github_repos"]["demo"] == "kai-linux/demo"
+
+
+def test_apply_tuning_overlays_operator_choices():
+    from orchestrator.init.config_emit import apply_tuning
+    payload = {
+        "sprint_cadence_days": 7,
+        "groomer_cadence_days": 3.5,
+        "max_parallel_workers": 1,
+        "dependency_watcher": {"enabled": True, "cadence_days": 7},
+    }
+    tuning = {"sprint_cadence_days": 14, "max_parallel_workers": 2, "dependency_watcher_cadence_days": 30}
+    apply_tuning(payload, tuning)
+    assert payload["sprint_cadence_days"] == 14
+    assert payload["max_parallel_workers"] == 2
+    # Nested dict merge, not replace — `enabled` must survive.
+    assert payload["dependency_watcher"]["cadence_days"] == 30
+    assert payload["dependency_watcher"]["enabled"] is True
+    # Untouched keys unchanged.
+    assert payload["groomer_cadence_days"] == 3.5
+
+
+def test_apply_tuning_noop_when_empty():
+    from orchestrator.init.config_emit import apply_tuning
+    payload = {"sprint_cadence_days": 7}
+    before = dict(payload)
+    apply_tuning(payload, None)
+    apply_tuning(payload, {})
+    assert payload == before

--- a/tests/test_init_tuning.py
+++ b/tests/test_init_tuning.py
@@ -1,0 +1,109 @@
+"""Coverage for the interactive tuning step added to `agentos init`.
+
+Previously the cadence/threshold knobs (sprint_cadence_days,
+groomer_cadence_days, max_parallel_workers, etc.) were hardcoded in
+config_emit.build_config with no way for the operator to set them during
+onboarding. A freshly onboarded project had to be hand-edited after the
+fact. The tuning step walks the operator through each knob with the
+current value as default so hitting enter preserves what's already set.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.init import tuning
+from orchestrator.init.state import State
+
+
+def _fresh_state(tmp_path: Path) -> State:
+    return State(path=tmp_path / "demo.json", data={})
+
+
+def test_tuning_uses_agentos_defaults_when_no_existing_cfg(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    # Simulate operator pressing enter on every prompt.
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: kwargs.get("default", ""))
+
+    result = tuning.run(state, existing_cfg=None)
+
+    # Accepting every default means no overrides are recorded — the tuning
+    # dict is empty and config_emit will use the hardcoded build_config defaults.
+    assert result == {}
+
+
+def test_tuning_captures_operator_overrides(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    # Operator raises sprint cadence from 7 to 14, leaves everything else.
+    prompts = iter([
+        "14",   # sprint_cadence_days
+        "",     # groomer_cadence_days (accept)
+        "",     # max_parallel_workers (accept)
+        "",     # max_runtime_minutes (accept)
+        "",     # plan_size (accept)
+        "",     # default_max_attempts (accept)
+        "",     # dependency_watcher_cadence_days (accept)
+    ])
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: next(prompts) or kwargs.get("default", ""))
+
+    result = tuning.run(state, existing_cfg=None)
+
+    assert result == {"sprint_cadence_days": 14}
+
+
+def test_tuning_uses_existing_cfg_as_default(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    # Operator previously set sprint=14, groomer=7. If they press enter, those
+    # existing values must survive — don't snap back to Agent OS defaults.
+    existing = {
+        "sprint_cadence_days": 14,
+        "groomer_cadence_days": 7,
+        "dependency_watcher": {"cadence_days": 30, "enabled": True},
+    }
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: kwargs.get("default", ""))
+
+    result = tuning.run(state, existing_cfg=existing)
+
+    # All accepts match existing values → no overrides needed (they're already
+    # in config.yaml and merge_config preserves them).
+    assert result == {}
+
+
+def test_tuning_casts_to_correct_types(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    prompts = iter([
+        "7",     # sprint_cadence_days (int)
+        "1.75",  # groomer_cadence_days (float)
+        "2",     # max_parallel_workers (int)
+        "60",    # max_runtime_minutes (int)
+        "3",     # plan_size (int)
+        "5",     # default_max_attempts (int)
+        "14",    # dependency_watcher_cadence_days (int)
+    ])
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: next(prompts))
+
+    result = tuning.run(state, existing_cfg=None)
+
+    assert result["groomer_cadence_days"] == 1.75
+    assert isinstance(result["groomer_cadence_days"], float)
+    assert result["max_parallel_workers"] == 2
+    assert isinstance(result["max_parallel_workers"], int)
+
+
+def test_tuning_resume_returns_stored_values(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    state.mark("tuning", {"plan_size": 3})
+    # Should NOT prompt on resume; returns stored value directly.
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not prompt")))
+
+    assert tuning.run(state, existing_cfg=None) == {"plan_size": 3}
+
+
+def test_tuning_handles_invalid_input_by_keeping_default(monkeypatch, tmp_path):
+    state = _fresh_state(tmp_path)
+    prompts = iter(["not-a-number", "", "", "", "", "", ""])
+    monkeypatch.setattr(tuning.ui, "prompt", lambda *args, **kwargs: next(prompts))
+
+    result = tuning.run(state, existing_cfg=None)
+
+    # Bad parse → keep default → no override recorded
+    assert result == {}


### PR DESCRIPTION
## Summary
Three ergonomic fixes for \`bin/agentos init\` so rerunning it for a new project doesn't silently clobber the operator's existing configuration and so a newly onboarded repo starts life with the right documents in place.

### 1. Preserve existing \`config.yaml\` scalars
The previous merge path unconditionally overwrote \`telegram_bot_token\`, \`telegram_chat_id\`, and the repo's own \`github_projects[name]\` / \`github_repos[name]\` entries every time init ran. These now \`setdefault\` — first-run values land as before, re-runs keep what the operator already set. Added a confirmation prompt at the write step so the operator sees what's about to happen and can abort to hand-edit if preferred.

### 2. New "Step 5/8 — Tuning cadence and thresholds"
Walks the operator through the knobs that used to be hardcoded in \`build_config\`:
- \`sprint_cadence_days\`
- \`groomer_cadence_days\`
- \`max_parallel_workers\`
- \`max_runtime_minutes\`
- \`plan_size\`
- \`default_max_attempts\`
- \`dependency_watcher.cadence_days\`

Defaults come from the existing config when present, so pressing enter preserves what's already set. Only records an override when the chosen value differs from the existing-config default, to keep the config minimal.

### 3. Extended charter output: VISION + STRATEGY + PLANNING_PRINCIPLES
The architect prompt now also produces \`VISION.md\`, \`STRATEGY.md\`, and \`PLANNING_PRINCIPLES.md\` alongside \`NORTH_STAR.md\`. The commit step writes only the docs actually returned — older payloads that only have \`north_star_md\` still commit cleanly, so a resumed init from before this change doesn't break.

## Test plan
- [x] \`pytest tests/test_init_*\` — 30 passed (12 new)
- [x] \`pytest tests/\` excluding the big slow suites — 529 passed

## Follow-up discovered while writing this
The \`_ensure_repo_initialized\` flow in github_scaffold (merged yesterday in #335) already adds \`.agent_result.md\` to \`.gitignore\`. The vision/strategy/principles docs land in the initial charter commit, so they benefit from the same ignore-the-handoff-contract protection automatically.