### PR TITLE
Fix template-echo escalation loop + auto-close linked issues on PR merge

### DIFF
--- a/orchestrator/github_dispatcher.py
+++ b/orchestrator/github_dispatcher.py
@@ -818,6 +818,26 @@ def _parse_log_result_section(text: str, label: str, next_labels: list[str]) -> 
     return match.group(1).strip() if match else ""
 
 
+def _sanitize_snapshot_blocker_code(raw: str) -> str:
+    """Map a raw blocker_code string into a value useful for escalation.
+
+    The worker log stores the literal line following ``BLOCKER_CODE:``. When
+    an agent echoed the prompt template instead of replacing it, that line is
+    the instruction prose (e.g. "One line. Required when STATUS..."). The
+    escalation message and error-pattern aggregator are not useful when they
+    display that prose. Treat any value not in ``VALID_BLOCKER_CODES`` as
+    ``invalid_result_contract`` so patterns aggregate cleanly and the
+    operator immediately sees the real problem.
+    """
+    from orchestrator.queue import VALID_BLOCKER_CODES  # lazy to avoid import cycle
+    normalized = str(raw or "").strip().strip("`").lower()
+    if normalized in {"", "none", "- none", "n/a", "na"}:
+        return "none"
+    if normalized in VALID_BLOCKER_CODES:
+        return normalized
+    return "invalid_result_contract"
+
+
 def _extract_task_result_snapshot(paths: dict, task_id: str, body: str) -> dict:
     log_path = paths["LOGS"] / f"{task_id}.log"
     if log_path.exists():
@@ -829,11 +849,12 @@ def _extract_task_result_snapshot(paths: dict, task_id: str, body: str) -> dict:
             "SUMMARY",
             ["DONE", "BLOCKERS", "NEXT_STEP", "FILES_CHANGED", "TESTS_RUN", "DECISIONS", "RISKS", "ATTEMPTED_APPROACHES", "MANUAL_STEPS"],
         )
-        blocker_code = _parse_log_result_section(
+        raw_blocker_code = _parse_log_result_section(
             text,
             "BLOCKER_CODE",
             ["SUMMARY", "DONE", "BLOCKERS", "NEXT_STEP", "FILES_CHANGED", "TESTS_RUN", "DECISIONS", "RISKS", "ATTEMPTED_APPROACHES", "MANUAL_STEPS"],
         ).splitlines()[0].strip() if "BLOCKER_CODE:" in text else ""
+        blocker_code = _sanitize_snapshot_blocker_code(raw_blocker_code) if raw_blocker_code else "unknown"
         blockers = _parse_log_result_section(
             text,
             "BLOCKERS",

--- a/orchestrator/github_sync.py
+++ b/orchestrator/github_sync.py
@@ -506,7 +506,10 @@ def sync_result(meta: dict, result: dict, commit_hash: str | None):
             repo,
             branch,
             f"Agent: {task_id}",
-            f"Automated changes for issue #{issue_number}",
+            # `Closes #N` is a GitHub closing keyword; without it, merging the
+            # PR leaves the issue open and escalations keep firing on
+            # long-completed work.
+            f"Closes #{issue_number}\n\nAutomated changes for issue #{issue_number}.",
         )
         if pr_url:
             comment += f"\n### PR\n{pr_url}\n"

--- a/orchestrator/pr_monitor.py
+++ b/orchestrator/pr_monitor.py
@@ -515,8 +515,15 @@ def _create_prs_for_orphan_branches(cfg: dict, repos: set[str]):
             # Try to find the linked issue number for proper cleanup on merge
             issue_number = _find_issue_for_task(repo, task_id)
             if issue_number:
+                # Use `Closes #N` so GitHub auto-closes the linked issue when
+                # the PR merges. The previous wording ("Automated changes for
+                # issue #N") is not a closing keyword — merged PRs left their
+                # issues open, which kept the escalation poller firing on
+                # long-done work (e.g. eigendark-website#77 triggered a
+                # blocked-task escalation a day after its fix shipped).
                 body = (
-                    f"Automated changes for issue #{issue_number}\n\n"
+                    f"Closes #{issue_number}\n\n"
+                    f"Automated changes for issue #{issue_number}.\n\n"
                     f"## Original Task ID\n{task_id}\n"
                 )
             else:

--- a/orchestrator/queue.py
+++ b/orchestrator/queue.py
@@ -2352,49 +2352,43 @@ Prior model attempts in this task lineage:
 
 You must create or overwrite a file named .agent_result.md in the repository root before exiting.
 
-Use EXACTLY this format:
+Use EXACTLY this format. The lines inside <...> brackets are placeholders —
+replace them with your actual answer. Do NOT copy the template verbatim.
 
-STATUS: complete|partial|blocked
+STATUS: <one of: complete, partial, blocked>
 
 BLOCKER_CODE:
-One line. Required when STATUS is partial or blocked. Use `none` when STATUS is complete.
+<one blocker code from the Rules list below, or `none` when STATUS is complete>
 
 SUMMARY:
-One short paragraph.
+<one short paragraph describing what you did this run>
 
 DONE:
-- bullet
-- bullet
+- <one concrete thing you completed; add more lines or remove if none>
 
 BLOCKERS:
-- bullet
-- bullet
+- <one real blocker; write a single line `- None` when nothing is blocking>
 
 NEXT_STEP:
-One short paragraph. If complete, write: None
+<one short paragraph for the next run, or the literal word None when STATUS is complete>
 
 FILES_CHANGED:
-- path
-- path
+- <repo-relative path you modified; write `- None` when no files changed>
 
 TESTS_RUN:
-- command + result
-- command + result
+- <command + pass/fail result, e.g. `pytest -q → 42 passed`; `- None` when no tests ran>
 
 DECISIONS:
-- bullet
-- bullet
+- <decision you made and why; `- None` when no notable decisions>
 
 RISKS:
-- bullet
-- bullet
+- <risk you're leaving behind for future runs; `- None` when none>
 
 ATTEMPTED_APPROACHES:
-- bullet
-- bullet
+- <approach you tried this run, successful or not, so future runs do not repeat a failed path>
 
 MANUAL_STEPS:
-- None
+- <action the operator must take before automation can continue; `- None` when none>
 
 Rules:
 - Prefer the smallest viable diff.
@@ -2407,6 +2401,7 @@ Rules:
 {result_contract_blocker_guidance()}
 - Always write .agent_result.md even if no code changes were made
 - In ATTEMPTED_APPROACHES, describe what you tried this run so future runs do not repeat the same failed path
+- Never copy the <...> placeholders into your answer. Replace each with a real value or with `None`.
 - Read the prior model attempts above and avoid repeating clearly failed approaches unless you have a specific new reason
 - Automation-first escalation policy: before emitting ANY item under MANUAL_STEPS
   or marking the task blocked on a "manual action", attempt to automate it. The

--- a/tests/test_blocker_code_template_echo.py
+++ b/tests/test_blocker_code_template_echo.py
@@ -1,0 +1,89 @@
+"""Regression coverage for the 2026-04-23 blocked-task escalation incident.
+
+eigendark-website#77 escalated because every attempt's `.agent_result.md`
+contained the prompt template echoed verbatim — including the literal
+instruction text "One line. Required when STATUS is partial or blocked.
+Use `none` when STATUS is complete." as the value for `BLOCKER_CODE:`.
+
+Three layered root causes are exercised here:
+
+1. The snapshot extractor (``_extract_task_result_snapshot``) read the raw
+   log text after ``BLOCKER_CODE:`` without validating it, so the echoed
+   prose flowed into the escalation Telegram and the error-pattern
+   aggregator — drowning the real signal.
+
+2. The prompt template itself used prose placeholders ("One line...",
+   "- bullet") that look plausibly like content. Fixed by replacing them
+   with unambiguous ``<...>`` markers + an explicit "do not copy
+   placeholders" rule. This test pins the template text so a future
+   refactor can't silently reintroduce the prose.
+
+3. Orphan-branch PRs used "Automated changes for issue #N" — not a
+   GitHub closing keyword — so merging the PR left its issue open with
+   the ``in-progress`` label and kept the escalation poller firing.
+"""
+from __future__ import annotations
+
+from orchestrator.github_dispatcher import _sanitize_snapshot_blocker_code
+
+
+def test_sanitize_known_code_passes_through():
+    assert _sanitize_snapshot_blocker_code("missing_context") == "missing_context"
+    assert _sanitize_snapshot_blocker_code("MISSING_CONTEXT") == "missing_context"
+    assert _sanitize_snapshot_blocker_code("  test_failure  ") == "test_failure"
+
+
+def test_sanitize_empty_or_none_becomes_none():
+    assert _sanitize_snapshot_blocker_code("") == "none"
+    assert _sanitize_snapshot_blocker_code("none") == "none"
+    assert _sanitize_snapshot_blocker_code("- None") == "none"
+    assert _sanitize_snapshot_blocker_code("n/a") == "none"
+
+
+def test_sanitize_rejects_echoed_template_prose():
+    """Agent copied the template literally — must not leak into escalation."""
+    echoed = "One line. Required when STATUS is partial or blocked. Use `none` when STATUS is complete."
+    assert _sanitize_snapshot_blocker_code(echoed) == "invalid_result_contract"
+
+
+def test_sanitize_rejects_arbitrary_freeform_text():
+    assert _sanitize_snapshot_blocker_code("I got stuck on the tests") == "invalid_result_contract"
+    assert _sanitize_snapshot_blocker_code("bullet") == "invalid_result_contract"
+
+
+def test_sanitize_strips_stray_backticks():
+    # Some agents wrap the value in backticks because the rules mention
+    # `code` formatting for the enum — the sanitizer should see through that.
+    assert _sanitize_snapshot_blocker_code("`missing_context`") == "missing_context"
+
+
+def test_prompt_template_uses_placeholders_not_prose():
+    """Pin the prompt template so the prose-placeholder bug can't regress."""
+    from orchestrator import queue
+    import inspect
+
+    # The template is embedded inside the source of `build_agent_prompt` or
+    # similar; scan queue.py module source for the signature strings.
+    source = inspect.getsource(queue)
+    # Positive: the new <...> placeholders are present.
+    assert "<one of: complete, partial, blocked>" in source
+    assert "<one blocker code from the Rules list below, or `none` when STATUS is complete>" in source
+    assert "Never copy the <...> placeholders into your answer." in source
+    # Negative: the old prose placeholders are gone (these were the ones
+    # agents kept echoing).
+    assert "One line. Required when STATUS is partial or blocked." not in source
+    # The dangling "- bullet\n- bullet" placeholder pair is also gone.
+    assert "- bullet\n- bullet" not in source
+
+
+def test_pr_body_uses_closes_keyword_for_linked_issue():
+    """Merged PRs must auto-close their linked issue. The old wording
+    ('Automated changes for issue #N') is NOT a closing keyword."""
+    import inspect
+    from orchestrator import pr_monitor, github_sync
+
+    pr_monitor_src = inspect.getsource(pr_monitor)
+    github_sync_src = inspect.getsource(github_sync)
+    # Both PR-creation paths must use `Closes #` now.
+    assert 'f"Closes #{issue_number}' in pr_monitor_src
+    assert 'f"Closes #{issue_number}' in github_sync_src

--- a/tests/test_gh_project.py
+++ b/tests/test_gh_project.py
@@ -435,12 +435,15 @@ def test_create_prs_for_orphan_branches_audits_opened_pr(monkeypatch):
 
     pm._create_prs_for_orphan_branches({"root_dir": "/tmp/test-root"}, {"owner/repo"})
 
+    # Body must start with `Closes #42` so GitHub auto-closes the linked issue
+    # on merge. Without this, agent PRs leave their issues open and the
+    # blocked-task escalation keeps firing on long-completed work.
     assert pr_calls == [
         (
             "owner/repo",
             "agent/task-123",
             "Agent: task-123",
-            "Automated changes for issue #42\n\n## Original Task ID\ntask-123\n",
+            "Closes #42\n\nAutomated changes for issue #42.\n\n## Original Task ID\ntask-123\n",
         )
     ]
     assert audit_calls and audit_calls[0][0] == "autonomous_pr_opened"


### PR DESCRIPTION
## Summary
The 2026-04-23 blocked-task escalation on eigendark-website#77 was caused by three cascading bugs. Fixing all three.

### Context
Telegram alert:
> 🛑 Blocked task escalation — eigendark-website#77 — Attempts: 3, Blocked age: 1 day. Blocker codes: \`One line. Required when STATUS is partial or blocked...\`

The blocker "code" was the literal prompt template text. Root causes:

### 1. Prose placeholders in the .agent_result.md template
Agents (codex in this case) copied the template verbatim. The old template had "One line. Required when STATUS..." and "- bullet / - bullet" which look plausibly like content.
**Fix**: replace with \`<...>\` markers, explicit "never copy the placeholders" rule.

### 2. Snapshot extractor didn't validate BLOCKER_CODE
\`_extract_task_result_snapshot\` read the raw log text after \`BLOCKER_CODE:\` without checking \`VALID_BLOCKER_CODES\`. That's why the echoed prose flowed into the Telegram and into the error-pattern aggregator.
**Fix**: new \`_sanitize_snapshot_blocker_code\` maps unknown values to \`invalid_result_contract\` so aggregation stays useful.

### 3. Agent PRs didn't auto-close their linked issue
Both \`_create_prs_for_orphan_branches\` (pr_monitor) and github_sync wrote "Automated changes for issue #N" as the PR body — **not** a GitHub closing keyword. Merging the PR left the issue open with \`in-progress\`, which kept the blocked-task poller firing on work that was long done.
**Fix**: both paths now lead with \`Closes #N\`.

### Also
Closed eigendark-website#77 manually (the page has been rendering correctly since PR #88 merged yesterday).

## Test plan
- [x] \`pytest tests/test_blocker_code_template_echo.py\` — 7 new tests (sanitizer enum, placeholder stripping, template-text pin, Closes-keyword pin)
- [x] Updated \`tests/test_gh_project.py::test_create_prs_for_orphan_branches_audits_opened_pr\` to match new PR body
- [x] \`pytest tests/\` excluding the slow queue suite — 584 passed