### PR TITLE
Auto-resolve stale incidents before digest delivery

### DIFF
--- a/orchestrator/incident_router.py
+++ b/orchestrator/incident_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -310,6 +311,51 @@ def _send_incident(cfg: dict, incident: dict[str, Any], tier_cfg: dict[str, Any]
     return delivered
 
 
+def _is_incident_stale(incident: dict[str, Any]) -> tuple[bool, str]:
+    """Return (stale, reason) when an incident's underlying condition has resolved.
+
+    Incidents raised at ``sev3`` are held for the next ``regular_digest``
+    delivery window (typically the next morning). When the underlying PR
+    state changes in the meantime — e.g. stuck_pr_merge resolves because
+    the PR merged within minutes — the digest would otherwise ship a
+    stale alert hours or a full day later.
+
+    Checks GitHub for PR-typed incidents. Returns (True, reason) only when
+    authoritatively confirmed resolved; any lookup failure returns
+    (False, "") so we err on the side of delivering.
+    """
+    event = incident.get("event") or {}
+    source = str(event.get("source") or incident.get("source") or "")
+    event_type = str(event.get("type") or "")
+    repo = str(event.get("repo") or "").strip()
+    pr_number = event.get("pr_number")
+    if not repo or not pr_number:
+        return (False, "")
+    if source not in {"pr_monitor", "work_verifier"} and "pr" not in event_type.lower():
+        return (False, "")
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "-R", repo, "--json", "state,mergedAt,mergeStateStatus"],
+            capture_output=True, text=True, timeout=20, check=False,
+        )
+        if result.returncode != 0:
+            return (False, "")
+        payload = json.loads(result.stdout or "{}")
+    except (OSError, json.JSONDecodeError, subprocess.TimeoutExpired):
+        return (False, "")
+    state = str(payload.get("state") or "").upper()
+    if state == "MERGED":
+        return (True, f"PR #{pr_number} merged at {payload.get('mergedAt')}")
+    if state == "CLOSED":
+        return (True, f"PR #{pr_number} closed without merge")
+    # For still-OPEN PRs, check if the specific condition has cleared.
+    merge_state = str(payload.get("mergeStateStatus") or "").upper()
+    if event_type == "stuck_pr_merge" and merge_state == "CLEAN":
+        # Stuck-merge alert, but PR is now cleanly mergeable — condition cleared.
+        return (True, f"PR #{pr_number} now CLEAN (stuck-merge condition cleared)")
+    return (False, "")
+
+
 def _incident_due(router_cfg: dict, incident: dict[str, Any], now: datetime) -> bool:
     severity = str(incident.get("sev") or "").lower()
     tier_cfg = dict(router_cfg["tiers"].get(severity) or {})
@@ -336,6 +382,17 @@ def flush_pending(cfg: dict | None = None, *, now: datetime | None = None, logfi
         if incident.get("resolved_at") or incident.get("deduped_to") or incident.get("notified_at"):
             continue
         if not _incident_due(router_cfg, incident, current):
+            continue
+        # Guard against stale PR alerts: if the underlying PR merged or
+        # otherwise cleared between when the incident was raised and the
+        # digest fires, mark resolved and skip delivery. Without this, a
+        # stuck_pr_merge incident created at 15:55 and resolved at 16:00
+        # still ships to Telegram at the next digest_hour (09:00 next day).
+        stale, reason = _is_incident_stale(incident)
+        if stale:
+            incident["resolved_at"] = current.isoformat()
+            incident["auto_resolved_reason"] = reason
+            changed = True
             continue
         tier_cfg = dict(router_cfg["tiers"].get(incident.get("sev")) or {})
         if _send_incident(cfg, incident, tier_cfg, logfile=logfile, queue_summary_log=queue_summary_log):

--- a/tests/test_incident_router_skip_resolved.py
+++ b/tests/test_incident_router_skip_resolved.py
@@ -1,0 +1,170 @@
+"""Regression coverage for the 2026-04-24 stale-digest-alert incident.
+
+Five sev3 incidents landed in the Telegram digest at 09:00 UTC; four were
+about PRs that had already merged the previous afternoon:
+- pr_monitor stuck_pr_merge on agent-os#330 (created 15:55, PR merged 16:00)
+- work_verifier blocks on liminalconsultants#53/54/55 (created 18:15-25,
+  PRs merged 18:36)
+
+Only the fifth (agent-os#349) reflected a still-live condition.
+`flush_pending` never re-checked the underlying PR state before delivery,
+so any incident raised before the digest hour shipped regardless of
+whether its cause had since resolved. The fix: liveness probe via
+`gh pr view` right before delivery; if the PR is merged/closed, mark the
+incident resolved and skip.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+from orchestrator import incident_router as ir
+
+
+def _make_incident(event: dict, created_at: datetime, sev: str = "sev3") -> dict:
+    return {
+        "id": "deadbeef",
+        "sev": sev,
+        "source": str(event.get("source") or ""),
+        "event": event,
+        "event_key": "test",
+        "created_at": created_at.isoformat(),
+        "resolved_at": None,
+        "deduped_to": None,
+        "notified_at": None,
+    }
+
+
+def test_stale_probe_marks_incident_resolved_when_pr_merged(monkeypatch):
+    event = {
+        "source": "pr_monitor",
+        "type": "stuck_pr_merge",
+        "repo": "kai-linux/agent-os",
+        "pr_number": 330,
+    }
+    def fake_gh(cmd, capture_output=True, text=True, timeout=20, check=False):
+        return subprocess.CompletedProcess(
+            cmd, 0,
+            stdout=json.dumps({"state": "MERGED", "mergedAt": "2026-04-23T16:00:33Z", "mergeStateStatus": ""}),
+            stderr="",
+        )
+    monkeypatch.setattr(ir.subprocess, "run", fake_gh)
+
+    incident = _make_incident(event, datetime(2026, 4, 23, 15, 55, tzinfo=timezone.utc))
+    stale, reason = ir._is_incident_stale(incident)
+    assert stale is True
+    assert "merged" in reason.lower()
+
+
+def test_stale_probe_leaves_open_pr_alerts_untouched(monkeypatch):
+    event = {
+        "source": "work_verifier",
+        "type": "work_verifier_block",
+        "repo": "kai-linux/agent-os",
+        "pr_number": 349,
+    }
+    def fake_gh(cmd, capture_output=True, text=True, timeout=20, check=False):
+        return subprocess.CompletedProcess(
+            cmd, 0,
+            stdout=json.dumps({"state": "OPEN", "mergedAt": None, "mergeStateStatus": "BLOCKED"}),
+            stderr="",
+        )
+    monkeypatch.setattr(ir.subprocess, "run", fake_gh)
+
+    incident = _make_incident(event, datetime(2026, 4, 24, 8, 50, tzinfo=timezone.utc))
+    stale, _ = ir._is_incident_stale(incident)
+    assert stale is False
+
+
+def test_stale_probe_clears_stuck_merge_when_pr_now_clean(monkeypatch):
+    """A stuck_pr_merge alert fires when pr_monitor can't merge a CLEAN PR.
+    If a subsequent poll makes it CLEAN again, the alert is no longer useful."""
+    event = {
+        "source": "pr_monitor",
+        "type": "stuck_pr_merge",
+        "repo": "kai-linux/agent-os",
+        "pr_number": 999,
+    }
+    def fake_gh(cmd, capture_output=True, text=True, timeout=20, check=False):
+        return subprocess.CompletedProcess(
+            cmd, 0,
+            stdout=json.dumps({"state": "OPEN", "mergedAt": None, "mergeStateStatus": "CLEAN"}),
+            stderr="",
+        )
+    monkeypatch.setattr(ir.subprocess, "run", fake_gh)
+
+    incident = _make_incident(event, datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc))
+    stale, reason = ir._is_incident_stale(incident)
+    assert stale is True
+    assert "CLEAN" in reason
+
+
+def test_stale_probe_fails_open_on_gh_error(monkeypatch):
+    """GitHub API failure must not mark an incident resolved — we err on
+    the side of delivering rather than silently swallowing."""
+    event = {"source": "pr_monitor", "type": "stuck_pr_merge", "repo": "x/y", "pr_number": 1}
+    def boom(cmd, capture_output=True, text=True, timeout=20, check=False):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="network down")
+    monkeypatch.setattr(ir.subprocess, "run", boom)
+
+    stale, reason = ir._is_incident_stale(_make_incident(event, datetime.now(timezone.utc)))
+    assert stale is False
+    assert reason == ""
+
+
+def test_stale_probe_skips_non_pr_incidents(monkeypatch):
+    """Incidents without a PR number (e.g. queue-level task_blocked) must
+    not trigger gh lookups — the probe only applies to PR-typed incidents."""
+    called = []
+    monkeypatch.setattr(ir.subprocess, "run", lambda *a, **kw: called.append(1))
+    incident = _make_incident({"source": "queue", "type": "task_blocked"}, datetime.now(timezone.utc))
+    stale, _ = ir._is_incident_stale(incident)
+    assert stale is False
+    assert called == []  # no subprocess call made
+
+
+def test_flush_pending_auto_resolves_stale_incidents(tmp_path, monkeypatch):
+    """End-to-end: a queued digest-tier incident about a merged PR is
+    auto-resolved when flush_pending runs — no Telegram send attempted."""
+    cfg = {
+        "root_dir": str(tmp_path),
+        "incident_router": {
+            "business_timezone": "UTC",
+            "business_hours": {"start_hour": 9, "end_hour": 17},
+            "digest_hour": 9,
+            "tiers": {
+                "sev3": {"delivery": "regular_digest", "dedup_window_minutes": 0,
+                         "bypass_kill_switch": False, "snooze_minutes": 0,
+                         "handlers": [{"type": "telegram_chat"}]},
+            },
+            "sources": {},
+        },
+    }
+    (tmp_path / "runtime" / "incidents").mkdir(parents=True)
+    path = tmp_path / "runtime" / "incidents" / "incidents.jsonl"
+    incident = _make_incident(
+        {"source": "pr_monitor", "type": "stuck_pr_merge", "repo": "kai-linux/agent-os", "pr_number": 330},
+        datetime(2026, 4, 23, 15, 55, tzinfo=timezone.utc),
+    )
+    path.write_text(json.dumps(incident) + "\n")
+
+    def fake_gh(cmd, capture_output=True, text=True, timeout=20, check=False):
+        return subprocess.CompletedProcess(
+            cmd, 0,
+            stdout=json.dumps({"state": "MERGED", "mergedAt": "2026-04-23T16:00:33Z", "mergeStateStatus": ""}),
+            stderr="",
+        )
+    monkeypatch.setattr(ir.subprocess, "run", fake_gh)
+    send_calls = []
+    monkeypatch.setattr(ir, "_send_incident",
+                        lambda *args, **kw: send_calls.append(args) or True)
+
+    sent = ir.flush_pending(cfg, now=datetime(2026, 4, 24, 9, 0, tzinfo=timezone.utc))
+
+    assert sent == 0, "stale incident must not trigger a send"
+    assert send_calls == []
+    # State persisted: incident now resolved with auto-resolve reason.
+    rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+    assert rows[0]["resolved_at"] is not None
+    assert "merged" in rows[0]["auto_resolved_reason"].lower()


### PR DESCRIPTION
## Summary
Today's 09:00 Telegram digest delivered five sev3 incidents. Four were stale by 13–14 hours:

| Incident | Created | Underlying state |
|---|---|---|
| agent-os#330 stuck_pr_merge | 2026-04-23 15:55 | **merged** at 16:00 (5 min later) |
| liminalconsultants#53 work_verifier_block | 2026-04-23 18:15 | **merged** at 18:36 |
| liminalconsultants#54 work_verifier_block | 2026-04-23 18:25 | **merged** at 18:36 |
| liminalconsultants#55 work_verifier_block | 2026-04-23 18:25 | **merged** at 18:36 |
| agent-os#349 work_verifier_block | 2026-04-24 08:50 | OPEN (real, handled separately) |

## Root cause
\`incident_router.flush_pending\` only skipped delivery when an incident was already \`resolved_at / deduped_to / notified_at\`. It never re-checked the underlying condition before shipping the digest. Any incident raised before the next digest hour fired regardless of whether its cause had since cleared.

Historical volume: **221 stuck_pr_merge + 48 work_verifier_block** incidents in the file.

## Fix
New \`_is_incident_stale\` probe runs right before delivery on PR-typed incidents. Queries \`gh pr view\` for the PR's current state and marks resolved when:
- PR is MERGED or CLOSED, or
- A \`stuck_pr_merge\` alert's PR is now CLEAN (condition cleared)

Fails open on gh errors so network blips never swallow a real alert.

## Backfill
Swept the existing \`runtime/incidents/incidents.jsonl\`: 16 pending PR-typed incidents, **13 auto-resolved** (stale). 3 remain pending (real current blocks).

## PR #349 handled separately
Inspected the flagged paths (\`bin/run_library_scout.sh\`, \`example.config.yaml\`) — both benign. Documented findings on issue #348, closed the issue + PR.

## Test plan
- [x] \`pytest tests/test_incident_router_skip_resolved.py tests/test_incident_router.py\` — 13 passed (6 new)
- [x] Broad suite: 614 passed
- [x] Live backfill resolved 13 historical stale incidents; next digest flush should show a clean queue